### PR TITLE
simplify logic on popup.js

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -1,12 +1,10 @@
 ci = function (library) {
 var libraryUrls = {
   'angular' : 'https://ajax.googleapis.com/ajax/libs/angularjs/1.3.5/angular.min.js',
-  'jQuery' : 'https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js',
   'jquery' : 'https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js',
   'jquery1' : 'https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js',
   'three.js' : 'https://ajax.googleapis.com/ajax/libs/threejs/r69/three.min.js',
   'threejs' : 'https://ajax.googleapis.com/ajax/libs/threejs/r69/three.min.js',
-  'D3' : 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.3/d3.min.js',
   'd3' : 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.3/d3.min.js',
   'underscore' : 'https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min.js',
   'prototype' : 'https://ajax.googleapis.com/ajax/libs/prototype/1.7.2.0/prototype.js',
@@ -14,7 +12,7 @@ var libraryUrls = {
   'backbone' : 'https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.2/backbone-min.js'
 }
 
-var lib =document.createElement('script');
-lib.src = libraryUrls[library];
+var lib = document.createElement('script');
+lib.src = libraryUrls[library.toLowerCase()];
 document.head.appendChild(lib);
 }


### PR DESCRIPTION
Lookups on provided libraries can be simplified by lowercasing the input library.
