### PR TITLE
[master]: Do not replace https with httpss

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -23,7 +23,7 @@ chrome.extension.sendMessage({}, function(response) {
               }, undefined);
 
               if (foundLib) {
-                var url = foundLib.latest.replace('http', 'https');
+                var url = foundLib.latest.replace('http:', 'https:');
                 var libScript =document.createElement('script');
                 libScript.src = url;
                 document.head.appendChild(libScript);


### PR DESCRIPTION
First of all, thank you for this useful little extension. It saved me a lot of time:)
Recently cloudflare has become https based, therefore the following happens:

> console.inject('lodash');
> undefined
> VM3828:33 XHR finished loading: GET "https://api.cdnjs.com/libraries?search=lodash".getURLs @ VM3828:33console.inject @ VM3828:36(anonymous function) @ VM4021:2InjectedScript._evaluateOn @ VM3711:883InjectedScript._evaluateAndWrap @ VM3711:816InjectedScript.evaluate @ VM3711:682
> VM3828:22 library injected from httpss://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.9.3/lodash.min.js
> VM3828:21 GET httpss://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.9.3/lodash.min.js net::ERR_UNKNOWN_URL_SCHEME

I made a little fix for that.

Thanks,
D.
